### PR TITLE
Now easier to build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules
 webkitbuilds
+build
+cache
+.DS_Store

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,21 +1,17 @@
 module.exports = function(grunt) {
-  grunt.initConfig({
-    nodewebkit: {
-      options: {
-          build_dir: './webkitbuilds',
-          mac: true, 
-          win: false,
-          linux32: false,
-          linux64: false,
-          mac_icns: './src/icon.icns',
-          zip: true,
-          credits: './src/credits.html'
-      },
-      src: ['./src/**/*'] 
-    },
-  });
+    grunt.initConfig({
+        nodewebkit: {
+            options: {
+                buildDir: './build',
+                credits: './src/credits.html',
+                macIcns: './src/icon.icns',
+                platforms: ['osx']
+            },
+            src: './src/**/*'
+        },
+    });
 
-  grunt.loadNpmTasks('grunt-node-webkit-builder');
+    grunt.loadNpmTasks('grunt-node-webkit-builder');
 
-  grunt.registerTask('default', ['nodewebkit']);
+    grunt.registerTask('default', ['nodewebkit']);
 };

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A Gmail site-specific browser (SSB) by node-webkit.
 
 ### Getting Started
 
-1. Run `grunt`
-2. Open Gmail.app in release folder
+1. Run `npm install`
+1. Run `grunt nodewebkit`
+2. Open `build/Gmail/osx/Gmail.app`
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "Gmail-ssb",
+    "description": "A Gmail site-specific browser (SSB) by node-webkit.",
+    "repository" : {
+        "type" : "git",
+        "url" : "git://github.com/chagel/gmail-ssb.git"
+    },
+    "devDependencies": {
+        "grunt": "latest",
+        "grunt-node-webkit-builder": "latest"
+    }
+}
+

--- a/src/index.html
+++ b/src/index.html
@@ -4,13 +4,13 @@
 <meta http-equiv="refresh" content="2; url=https://mail.google.com/" />
 <style type="text/css">
 body {background-color: #e5e5e5;}
-.center {text-align: center; margin-top: 300px;}
+.center {text-align: center; margin-top: 310px;}
 .welcome {font-family: "Arial";font-size: 30px; }
 </style>
 </head>
 <body>
 <div class="center">
-  <span class="welcome">No Pain No Gain</span>
+  <span class="welcome">Welcome to Gmail.app</span>
 </div>
 </body>
 </html>

--- a/src/package.json
+++ b/src/package.json
@@ -1,17 +1,16 @@
 {
-  "name": "Gmail",
-  "version": "1.0",
-  "main": "index.html",
-  "window": {
-    "toolbar": false,
-    "frame": true,
-    "width": 1300,
-    "height": 800,
-    "position": "middle",
-    "icon": "icon.png"
-  },
-  "devDependencies": {
-    "grunt": "~0.4.5",
-    "grunt-node-webkit-builder": "~0.1.21"
-  }
+    "main": "index.html",
+    "name": "Gmail",
+    "version": "1.0.0",
+    "window": {
+        "toolbar": false,
+        "frame": true,
+        "width": 1100,
+        "height": 650,
+        "position": "middle",
+        "icon": "icon.png"
+    },
+    "webkit": {
+        "plugin": true
+    }
 }


### PR DESCRIPTION
I've made this much easier to build now. In particular I've:
- moved devDependencies to the root package.json (no need to be packaged into the app)
- removed the zip option
- cleaned up the grunt file
- made the window dimensions smaller for smaller screens
- added a few clearer directions in the readme
